### PR TITLE
Update README.md about installation from AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ $ brew tap eyeplum/tap
 $ brew install cicero-tui
 ```
 
+## Installation (AUR)
+
+`cicero` can be installed from available [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=cicero&outdated=&SB=n&SO=a&PP=50&do_Search=Go) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
+
+```sh
+$ yay -S cicero
+```
+
+If you prefer, you can clone the [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=cicero&outdated=&SB=n&SO=a&PP=50&do_Search=Go) and then compile them with [makepkg](https://wiki.archlinux.org/index.php/Makepkg). For example,
+
+```sh
+$ git clone https://aur.archlinux.org/cicero.git
+$ cd cicero
+$ makepkg -si
+```
+
 ## Installation (building from source)
 
 You can also build Cicero from source.


### PR DESCRIPTION
Hey,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following packages for the installation of `cicero` on Arch Linux and other distributions that support installing packages from [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository):

* [cicero](https://aur.archlinux.org/packages/cicero/) (builds from source)
* [cicero-git](https://aur.archlinux.org/packages/cicero-git/) (VCS/development package)

PS: I can create a `-bin` package if you provide a pre-compiled x86_64 binary along with the release artifacts.

I also updated README.md about installation from AUR. (ddaa04d)

BR,
orhun.