### PR TITLE
Remove empty string fallback for CLI

### DIFF
--- a/src/cli/input.rs
+++ b/src/cli/input.rs
@@ -66,16 +66,16 @@ pub fn parse_input(args: &ArgMatches) -> Result<Input> {
         return Ok(Input::GenerateFlamegraph);
     }
 
-    let input_string = &match args.value_of(ARGUMENT_VALUE_NAME_INPUT) {
-        Some(v) => v.to_string(),
+    let input_string = match args.value_of(ARGUMENT_VALUE_NAME_INPUT) {
+        Some(v) => Ok(v),
         None => {
             if args.is_present(FLAG_NAME_TUI_MODE) {
-                String::new() // Fallback to an empty string
+                Ok("") // Fallback to an empty string
             } else {
-                return Err(Box::new(Error::MissingInput));
+                Err(Box::new(Error::MissingInput))
             }
         }
-    };
+    }?;
 
     match args.value_of(OPTION_NAME_INPUT_TYPE) {
         Some(input_type) => match input_type {

--- a/src/cli/input.rs
+++ b/src/cli/input.rs
@@ -16,7 +16,10 @@ use std::char;
 
 use clap::ArgMatches;
 
-use super::{Error, Result, FLAG_NAME_CODE_POINT_INPUT_MODE, FLAG_NAME_GENERATE_FLAMEGRAPH};
+use super::{
+    Error, Result, FLAG_NAME_CODE_POINT_INPUT_MODE, FLAG_NAME_GENERATE_FLAMEGRAPH,
+    FLAG_NAME_TUI_MODE,
+};
 use crate::ucd::string_to_code_point;
 
 pub const OPTION_NAME_INPUT_TYPE: &str = "input_type";
@@ -63,7 +66,16 @@ pub fn parse_input(args: &ArgMatches) -> Result<Input> {
         return Ok(Input::GenerateFlamegraph);
     }
 
-    let input_string = args.value_of(ARGUMENT_VALUE_NAME_INPUT).unwrap_or(""); // No input is provided, fallback to an empty string
+    let input_string = &match args.value_of(ARGUMENT_VALUE_NAME_INPUT) {
+        Some(v) => v.to_string(),
+        None => {
+            if args.is_present(FLAG_NAME_TUI_MODE) {
+                String::new() // Fallback to an empty string
+            } else {
+                return Err(Box::new(Error::MissingInput));
+            }
+        }
+    };
 
     match args.value_of(OPTION_NAME_INPUT_TYPE) {
         Some(input_type) => match input_type {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -38,6 +38,7 @@ pub const FLAG_NAME_CODE_POINT_INPUT_MODE: &str = "code_point_input_mode";
 pub type Result<T> = std::result::Result<T, Box<dyn error::Error>>;
 
 pub enum Error {
+    MissingInput,
     UnrecognizedInputType(String),
     UnrecognizedOutputFormat(String),
 }
@@ -51,6 +52,7 @@ impl fmt::Debug for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Error::MissingInput => write!(f, "An input or `--tui` flag is expected"),
             Error::UnrecognizedInputType(input_type) => {
                 write!(f, "Unrecognized input type '{}'", input_type)
             }


### PR DESCRIPTION
I think it's not clear what is happening when `cicero` is run without any arguments. e.g.:

```sh
$ cicero

$
```

In this case, looks like an empty string is processed:

https://github.com/eyeplum/cicero-tui/blob/8c5b5c16dae8fc5bbb1406fda347c021ae09a0af/src/cli/input.rs#L66

In order to make it more clear I added a new `Error` type named `MissingInput` and it's thrown if the user does not provide any input:

```sh
$ cicero
Error: An input or `--tui` flag is expected
$
```

So `cicero` only fallbacks to an empty string if the `--tui` flag is given. Otherwise an error is thrown and user is made aware that they have to provide an input.

